### PR TITLE
Support extracting of .tar & decrypt multiple .tar.gz files

### DIFF
--- a/ha-backup-decrypt.csproj
+++ b/ha-backup-decrypt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>HA_BACKUP_DECRYPT</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
```
Usage: ha-backup-decrypt <input> <output> <key>
  <input>      encypted single tar.gz file or complete .tar backup with multiple encrypted tar.gz files
  <output>   output filename or destination directory
```